### PR TITLE
Added fix for istio gateway and vs heterogenous deployment

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
             {{- if .Values.triggerLoopOnEvent }}
             - --events
             {{- end }}
+            {{- if .Values.awsPreferCname }}
+            - --aws-prefer-cname
+            {{- end }}
             {{- if .Values.watchNamespaces }}
             - --namespace={{ .Values.watchNamespaces | join "," }}
             {{- end }}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -302,7 +302,7 @@ func (sc *virtualServiceSource) targetsFromVirtualService(ctx context.Context, v
 		if !virtualServiceBindsToGateway(virtualService, gateway, vsHost) {
 			continue
 		}
-		tgs, err := sc.targetsFromGateway(gateway)
+		tgs, err := sc.targetsFromGateway(ctx, gateway)
 		if err != nil {
 			return targets, err
 		}
@@ -431,19 +431,20 @@ func parseGateway(gateway string) (namespace, name string, err error) {
 	return
 }
 
-func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
+func (sc *virtualServiceSource) targetsFromGateway(ctx context.Context, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
 	targets = getTargetsFromTargetAnnotation(gateway.Annotations)
 	if len(targets) > 0 {
 		return
 	}
 
-	services, err := sc.serviceInformer.Lister().Services(sc.namespace).List(labels.Everything())
+	// Use kubeclient instead of informers to fetch services from gateway namespace
+	services, err := sc.kubeClient.CoreV1().Services(gateway.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Error(err)
 		return
 	}
 
-	for _, service := range services {
+	for _, service := range services.Items {
 		if !gatewaySelectorMatchesServiceSelector(gateway.Spec.Selector, service.Spec.Selector) {
 			continue
 		}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Currently there is no support to watch multiple namespaces due to a limitation in the client-go library. The informers doesn't support a list of namespaces due to which you can either watch one or all namespaces. With the evolution of multi-tenancy, heterogeneous deployments for example: Virtual Service and Gateway deployed on different namespaces is a very common use case. 
Because of the  above mentioned limitation, it's not possible to achieve the heterogeneous deployment scenario's. You can check this issue for one such failed scenario(https://github.com/kubernetes-sigs/external-dns/issues/2911).
 
With this PR, the GW sources are fetched by watching the gateway namespace instead of the virtualservice namespace.

Tested for both namespace and cluster scoped deployed on EKS with Route53.

To add more context to this PR, currently the gateway targets are fetched via the service metadata fetched as part of the informers watching the namespace where virtual services are deployed. This works well when both the virtual service and gateway resource are deployed in the same namespace but would fail if the gateway is deployed in another namespace. This PR fixes this problem by fetching the gateway targets directly from the gateway resource namespace.

This PR also introduces  an optional `aws-prefer-cname` flag which forces cname record creation.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2911

**Checklist**

- [ ] ~Unit tests updated~
- [ ] ~End user documentation updated~