### PR TITLE
Fix helm charts

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.13.0-20230727-1700-adobe
-appVersion: 0.13.5-20230727-1700-adobe
+version: 1.13.0-202300808-0900-adobe
+appVersion: 1.13.0-202300808-0900-adobe
 keywords:
   - kubernetes
   - externaldns

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.13.0-202300808-0900-adobe
+version: 1.13.0-20230808-0900-adobe
 appVersion: 0.13.5-20230727-1700-adobe
 keywords:
   - kubernetes

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
 version: 1.13.0-202300808-0900-adobe
-appVersion: 1.13.0-202300808-0900-adobe
+appVersion: 0.13.5-20230727-1700-adobe
 keywords:
   - kubernetes
   - externaldns

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -68,5 +68,5 @@ Create the name of the service account to use
 The image to use
 */}}
 {{- define "external-dns.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s:%s" .Values.image.repository (default ( .Chart.AppVersion) .Values.image.tag) }}
 {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -76,12 +76,13 @@ spec:
             {{- if .Values.awsPreferCname }}
             - --aws-prefer-cname
             {{- end }}
-            {{- if .Values.namespaced  }}
-            {{- range .Values.watchNamespaces }}
-            - --namespace={{ . }}
-            {{- end }}
-            {{ else }}
+            {{- if or .Values.namespaced .Values.watchNamespaces }}
+            {{- if .Values.watchNamespaces }}
+            - --namespace={{ .Values.watchNamespaces | join "," }}
+            {{- else }}
             - --namespace={{ .Release.Namespace }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- range .Values.sources }}
             - --source={{ . }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -76,8 +76,12 @@ spec:
             {{- if .Values.awsPreferCname }}
             - --aws-prefer-cname
             {{- end }}
-            {{- if .Values.watchNamespaces }}
-            - --namespace={{ .Values.watchNamespaces | join "," }}
+            {{- if .Values.namespaced  }}
+            {{- range .Values.watchNamespaces }}
+            - --namespace={{ . }}
+            {{- end }}
+            {{ else }}
+            - --namespace={{ .Release.Namespace }}
             {{- end }}
             {{- range .Values.sources }}
             - --source={{ . }}
@@ -92,9 +96,6 @@ spec:
             {{- end }}
             {{- if and (eq .Values.txtPrefix "") (ne .Values.txtSuffix "") }}
             - --txt-suffix={{ .Values.txtSuffix }}
-            {{- end }}
-            {{- if .Values.namespaced }}
-            - --namespace={{ .Release.Namespace }}
             {{- end }}
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
This PR fixes two helm chart issues:
1. Currently there is no conditional logic which switches between the `watchNamespaces` and release namespace. This PR adds as logic where if the deployment is namespace scoped, it should read the `watchNamespaces`.
2. The image parameter in the helpers file currently prefixes `v` to the image, however that is not required.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
