### PR TITLE
Added annotation filter

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.13.0-20230809-1331-adobe
+version: 1.13.0-20230821-1051-adobe
 appVersion: 0.13.5-20230727-1700-adobe
 keywords:
   - kubernetes

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             {{- if .Values.txtPrefix }}
             - --txt-prefix={{ .Values.txtPrefix }}
             {{- end }}
+            {{- if .Values.annotationFilter }}
+            - --annotationFilter={{ .Values.annotationFilter }}
+            {{- end }}
             {{- if and (eq .Values.txtPrefix "") (ne .Values.txtSuffix "") }}
             - --txt-suffix={{ .Values.txtSuffix }}
             {{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -162,6 +162,9 @@ sources:
 
 policy: upsert-only
 
+# Filters out resources based on annotations
+annotationFilter: ""
+
 # Specifies the registry for storing ownership and labels.
 # Valid values are "aws-sd", "noop", "dynamodb", and "txt".
 registry: txt


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

On a multi-tenant environment, it's important to filter out resources. This annotation filter is used to filter out the resources to be picked up for sync.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
